### PR TITLE
Stopped obfuscating stdout of tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,7 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
-      "outFiles": [
-        "${workspaceFolder}/out"
-      ]
+      "outFiles": ["${workspaceFolder}/out/**/*.js"]
     },
     {
       "name": "Extension Tests",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ steps:
       condition: eq(variables['Agent.JobName'], 'Job linux-old-devtools')
 
     - bash: |
-          Rscript -e "install.packages('devtools', repos = 'http://cran.us.r-project.org', type='binary');install.packages('mockery',repos = 'http://cran.us.r-project.org', type='binary')"
+          Rscript -e "install.packages('devtools', repos = 'http://cran.us.r-project.org', type='binary');install.packages('mockery',repos = 'http://cran.us.r-project.org', type='binary');install.packages('httr',repos = 'http://cran.us.r-project.org', type='binary')"
       displayName: "Install devtools"
       condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/winreg": "^1.2.32",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
-    "@vscode/test-electron": "^2.3.2",
+    "@vscode/test-electron": "^2.4.0",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "deep-equal-in-any-order": "^2.0.6",

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -293,12 +293,12 @@ async function runSingleTest(
     return runSingleTestFile(testingTools, run, test, tmpFilePath, true)
         .catch(async (err) => {
             await tmpFileResult.cleanup();
-            run.appendOutput(err);
+            run.appendOutput(err, undefined, test);
             throw err;
         })
         .then(async (value) => {
             await tmpFileResult.cleanup();
-            run.appendOutput(value);
+            run.appendOutput(value, undefined, test);
             return value;
         });
 }

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -292,7 +292,6 @@ async function runSingleTest(
     return runSingleTestFile(testingTools, run, test, tmpFilePath, true)
         .catch(async (err) => {
             await tmpFileResult.cleanup();
-            run.appendOutput(err, undefined, test);
             throw err;
         })
         .then(async (value) => {

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -293,6 +293,7 @@ async function runSingleTest(
     return runSingleTestFile(testingTools, run, test, tmpFilePath, true)
         .catch(async (err) => {
             await tmpFileResult.cleanup();
+            run.appendOutput(err, undefined, test);
             throw err;
         })
         .then(async (value) => {

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -68,7 +68,7 @@ async function runSingleTestFile(
         return Promise.reject(
             Error(
                 "Devtools version too old. RTestAdapter requires devtools>=2.3.2" +
-                "to be installed in the Rscript environment"
+                    "to be installed in the Rscript environment"
             )
         );
     }
@@ -85,83 +85,82 @@ async function runSingleTestFile(
         let childProcess = spawn(command, { cwd, shell: true });
         let stdout = "";
         let testStartDates = new WeakMap<vscode.TestItem, number>();
-        childProcess.stdout!.pipe(split2(
-            function (line: string): (TestResult | string) {
-                try {
-                    return JSON.parse(line) as TestResult;
-                }
-                catch (e) {
-                    return line + "\r\n";
-                }
-            })).on("data", function (data: TestResult | string) {
-                stdout += JSON.stringify(data);
-                if (typeof data === "string") {
-                    run.appendOutput(data, undefined, test);
-                    return;
-                }
-                switch (data.type) {
-                    case "start_test":
-                        if (data.test !== undefined) {
-                            let testItem = isSingleTest
-                                ? test
-                                : findTestRecursively(encodeNodeId(test.uri!.fsPath, data.test), test);
-                            if (testItem === undefined)
-                                reject(
-                                    `Test with id ${encodeNodeId(
-                                        test.uri!.fsPath,
-                                        data.test
-                                    )} could not be found. Please report this.`
+        childProcess.stdout!.pipe(
+            split2((line: string) => {
+              try {
+                return JSON.parse(line) as TestResult;
+              } catch {
+                return line + "\r\n";
+              }
+        })).on("data", function (data: TestResult | string) {
+            stdout += JSON.stringify(data);
+            if (typeof data === "string") {
+                run.appendOutput(data, undefined, test);
+                return;
+            }
+            switch (data.type) {
+                case "start_test":
+                    if (data.test !== undefined) {
+                        let testItem = isSingleTest
+                            ? test
+                            : findTestRecursively(encodeNodeId(test.uri!.fsPath, data.test), test);
+                        if (testItem === undefined)
+                            reject(
+                                `Test with id ${encodeNodeId(
+                                    test.uri!.fsPath,
+                                    data.test
+                                )} could not be found. Please report this.`
+                            );
+                        testStartDates.set(testItem!, Date.now());
+                        run.started(testItem!);
+                    }
+                    break;
+                case "add_result":
+                    if (data.result !== undefined && data.test !== undefined) {
+                        let testItem = isSingleTest
+                            ? test
+                            : findTestRecursively(encodeNodeId(test.uri!.fsPath, data.test), test);
+                        if (testItem === undefined)
+                            reject(
+                                `Test with id ${encodeNodeId(
+                                    test.uri!.fsPath,
+                                    data.test
+                                )} could not be found. Please report this.`
+                            );
+                        let duration = Date.now() - testStartDates.get(testItem!)!;
+                        switch (data.result) {
+                            case "success":
+                            case "warning":
+                                run.passed(testItem!, duration);
+                                if (data.message) {
+                                    run.appendOutput(data.message, undefined, testItem);
+                                }
+                                break;
+                            case "failure":
+                                run.failed(
+                                    testItem!,
+                                    new vscode.TestMessage(data.message!),
+                                    duration
                                 );
-                            testStartDates.set(testItem!, Date.now());
-                            run.started(testItem!);
-                        }
-                        break;
-                    case "add_result":
-                        if (data.result !== undefined && data.test !== undefined) {
-                            let testItem = isSingleTest
-                                ? test
-                                : findTestRecursively(encodeNodeId(test.uri!.fsPath, data.test), test);
-                            if (testItem === undefined)
-                                reject(
-                                    `Test with id ${encodeNodeId(
-                                        test.uri!.fsPath,
-                                        data.test
-                                    )} could not be found. Please report this.`
+                                break;
+                            case "skip":
+                                run.skipped(testItem!);
+                                if (data.message) {
+                                    run.appendOutput(data.message, undefined, testItem);
+                                }
+                                break;
+                            case "error":
+                                run.errored(
+                                    testItem!,
+                                    new vscode.TestMessage(data.message!),
+                                    duration
                                 );
-                            let duration = Date.now() - testStartDates.get(testItem!)!;
-                            switch (data.result) {
-                                case "success":
-                                case "warning":
-                                    run.passed(testItem!, duration);
-                                    if (data.message) {
-                                        run.appendOutput(data.message, undefined, testItem);
-                                    }
-                                    break;
-                                case "failure":
-                                    run.failed(
-                                        testItem!,
-                                        new vscode.TestMessage(data.message!),
-                                        duration
-                                    );
-                                    break;
-                                case "skip":
-                                    run.skipped(testItem!);
-                                    if (data.message) {
-                                        run.appendOutput(data.message, undefined, testItem);
-                                    }
-                                    break;
-                                case "error":
-                                    run.errored(
-                                        testItem!,
-                                        new vscode.TestMessage(data.message!),
-                                        duration
-                                    );
-                                    break;
-                            }
+                                break;
                         }
-                        break;
-                }
-            });
+                    }
+                    break;
+            }
+        });
         childProcess.once("exit", () => {
             stdout += childProcess.stderr.read();
             if (stdout.includes("Execution halted")) {
@@ -312,7 +311,7 @@ async function getRscriptCommand(testingTools: TestingTools) {
         } else {
             testingTools.log.warn(
                 `Rscript path given in the configuration ${configPath} is invalid. ` +
-                `Falling back to defaults.`
+                    `Falling back to defaults.`
             );
         }
     }
@@ -355,7 +354,7 @@ async function getRscriptCommand(testingTools: TestingTools) {
                 RscriptPath = possibleRscriptPath;
                 return Promise.resolve(`"${RscriptPath}"`);
             }
-        } catch (e) { }
+        } catch (e) {}
     }
     throw Error("Rscript could not be found in PATH, cannot run the tests.");
 }
@@ -367,7 +366,7 @@ async function getDevtoolsVersion(
     return new Promise(async (resolve, reject) => {
         let childProcess = spawn(
             `${RscriptCommand} -e "suppressMessages(library('devtools'));` +
-            `packageVersion('devtools')"`,
+                `packageVersion('devtools')"`,
             {
                 shell: true,
             }

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -94,6 +94,7 @@ async function runSingleTestFile(
                     return line + "\r\n";
                 }
             })).on("data", function (data: TestResult | string) {
+                stdout += JSON.stringify(data);
                 if (typeof data === "string") {
                     run.appendOutput(data, undefined, test);
                     return;
@@ -292,12 +293,10 @@ async function runSingleTest(
     return runSingleTestFile(testingTools, run, test, tmpFilePath, true)
         .catch(async (err) => {
             await tmpFileResult.cleanup();
-            run.appendOutput(err, undefined, test);
             throw err;
         })
         .then(async (value) => {
             await tmpFileResult.cleanup();
-            run.appendOutput(value, undefined, test);
             return value;
         });
 }

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -97,6 +97,7 @@ async function runSingleTestFile(
                     return;
                 }
                 const data = parsedObject as TestResult;
+                stdout += JSON.stringify(data);
                 if (data === null) {
                     throw Error("Corrupt VSCodeReporter output: " + JSON.stringify(data));
                 }

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -86,17 +86,16 @@ async function runSingleTestFile(
         let stdout = "";
         let testStartDates = new WeakMap<vscode.TestItem, number>();
         childProcess.stdout!.pipe(split2(
-            function (line: string) {
-                stdout += line + "\r\n";
+            function (line: string): (TestResult | string) {
                 try {
-                    return JSON.parse(line);
+                    return JSON.parse(line) as TestResult;
                 }
                 catch (e) {
-                    // What we just got is plain stdout from the tested code and not VSCodeReporter output
-                    return null;
+                    return line + "\r\n";
                 }
-            })).on("data", function (data: TestResult | null) {
-                if (data === null) {
+            })).on("data", function (data: TestResult | string) {
+                if (typeof data === "string") {
+                    run.appendOutput(data, undefined, test);
                     return;
                 }
                 switch (data.type) {


### PR DESCRIPTION
This PR fixes a bug where the output of tests gets obfuscated by R Test Adapter.

Rationale:
The current implementation of R Test Adapter uses `stdout!.pipe(split2(JSON.parse))` to parse the VSCodeReporter from testthat. But the problem starts when your R code prints logs to stdout in plain text (which of course are not parseable by `JSON.parse`). In that case the whole `stdout!.pipe(split2(JSON.parse))` pipe silently crashes and you are left with no reports at all which obfuscates any logs and is confusing for the user.
This PR fixes this behavior by just printing the unparsable messages back to stdout of the test instead of silently crashing the whole test.

With this change I'm able to see the stdout of my `testthat` tests:
![image](https://github.com/user-attachments/assets/610a26c7-3545-4df6-8a2e-188bd849aefb)

Without this change the stdout of the test causes a silent crash of R Test Adapter and you are left with no meaningful message:
![image](https://github.com/user-attachments/assets/b65e6823-fd6f-4b2c-8562-eac8fe26e223)

