### PR TITLE
Improved configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ Additionally, in order to debug tests, you will need to install:
  1. the [R Debugger extension](https://marketplace.visualstudio.com/items/?itemName=RDebugger.r-debugger)
  2. the [vscDebugger](https://github.com/ManuelHentschel/vscDebugger) package in R
 
-Only the following file paths are searched for tests (TODO: add .vscode/settings.json options to specify that):
- - `tinytest`: `"**/inst/tinytest/**/test*.R"`
- - `testthat`: `"**/tests/testthat/**/test*.R"`
+## Configuration
+
+The following parameters are supported .vscode/settings.json.
+
+#### R package root
+
+The following option is used in the `devtools::load_all` call
+in the R code entry point. Empty value means the current workspace folder
+in VSCode.
+
+```json
+{
+    "RTestAdapter.RPackageRoot": "" // default
+}
+```
+
+#### Test search paths
+
+The following two options define where to look for tests relative to the current workspace folder.
+After modifying those entries, please use the 'Rediscover tests' button in the top of the Testing Tab.
+```json
+{
+    "RTestAdapter.testthatSearchPath": "**/tests/testthat/**/test*.R",  // default
+    "RTestAdapter.tinytestSearchPath": "**/inst/tinytest/**/test*.R"    // default
+}
+```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,8 @@ steps:
           sudo apt-get update
           sudo apt-get install libcurl4-gnutls-dev libssh2-1-dev libgit2-dev libxml2-dev
           sudo apt-get install r-cran-devtools
-          sudo Rscript -e "install.packages('mockery',repos = 'http://cran.us.r-project.org')"
-          sudo Rscript -e "install.packages('tinytest', repos = 'http://cran.us.r-project.org')"
+          sudo Rscript -e "install.packages('mockery',repos = 'http://cran.r-project.org')"
+          sudo Rscript -e "install.packages('tinytest', repos = 'http://cran.r-project.org')"
       displayName: "Install devtools for Linux"
       condition: eq(variables['Agent.JobName'], 'Job linux')
 
@@ -53,20 +53,20 @@ steps:
           sudo add-apt-repository ppa:marutter/c2d4u
           sudo apt-get update
           sudo apt-get install libcurl4-gnutls-dev libssh2-1-dev libgit2-dev libxml2-dev
-          sudo Rscript -e "install.packages('remotes', repos = 'http://cran.us.r-project.org')"
+          sudo Rscript -e "install.packages('remotes', repos = 'http://cran.r-project.org')"
           sudo Rscript -e "remotes::install_version('devtools', version='2.3.2')"
-          sudo Rscript -e "install.packages('mockery', repos = 'http://cran.us.r-project.org')"
-          sudo Rscript -e "install.packages('tinytest', repos = 'http://cran.us.r-project.org')"
+          sudo Rscript -e "install.packages('mockery', repos = 'http://cran.r-project.org')"
+          sudo Rscript -e "install.packages('tinytest', repos = 'http://cran.r-project.org')"
       displayName: "Install previous version of devtools for Linux"
       condition: eq(variables['Agent.JobName'], 'Job linux-old-devtools')
 
     - bash: |
-          Rscript -e "install.packages('devtools', repos = 'http://cran.us.r-project.org', type='binary');install.packages('mockery',repos = 'http://cran.us.r-project.org', type='binary');install.packages('httr',repos = 'http://cran.us.r-project.org', type='binary'); install.packages('tinytest', repos = 'http://cran.us.r-project.org')"
+          Rscript -e "install.packages('devtools', repos = 'http://cran.r-project.org', type='binary');install.packages('mockery',repos = 'http://cran.r-project.org', type='binary');install.packages('httr',repos = 'http://cran.r-project.org', type='binary'); install.packages('tinytest', repos = 'http://cran.r-project.org')"
       displayName: "Install devtools"
       condition: eq(variables['Agent.OS'], 'Windows_NT')
 
     - bash: |
-          Rscript -e "install.packages('devtools', repos = 'http://cran.us.r-project.org', type='mac.binary');install.packages('mockery',repos = 'http://cran.us.r-project.org', type='mac.binary'); install.packages('tinytest', repos = 'http://cran.us.r-project.org')"
+          Rscript -e "install.packages('devtools', repos = 'http://cran.r-project.org', type='mac.binary');install.packages('mockery',repos = 'http://cran.r-project.org', type='mac.binary'); install.packages('tinytest', repos = 'http://cran.r-project.org')"
       displayName: "Install devtools"
       condition: eq(variables['Agent.OS'], 'Darwin')
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,23 @@
     "onView:test-explorer"
   ],
   "contributes": {
+    "commands": [
+      {
+        "command": "RTestAdapter.rediscover",
+        "title": "R Test Adapter: rediscover tests",
+        "icon": "$(refresh)",
+        "category": "My Testing"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "RTestAdapter.rediscover",
+          "when": "view == workbench.view.testing",
+          "group": "navigation@1"
+        }
+      ]
+    },
     "configuration": {
       "type": "object",
       "title": "R Test Explorer configuration",
@@ -116,6 +133,24 @@
           "description": "Path to the Rscript binary",
           "type": "string",
           "scope": "resource"
+        },
+        "RTestAdapter.testthatSearchPath": {
+          "description": "Path to the testthat tests",
+          "type": "string",
+          "scope": "resource",
+          "default": "**/tests/testthat/**/test*.R"
+        },
+        "RTestAdapter.tinytestSearchPath": {
+          "description": "Path to the tinytest tests",
+          "type": "string",
+          "scope": "resource",
+          "default": "**/inst/tinytest/**/test*.R"
+        },
+        "RTestAdapter.RPackageRoot": {
+          "description": "Root folder of the R package",
+          "type": "string",
+          "scope": "resource",
+          "default": ""
         }
       }
     }

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -37,9 +37,13 @@ export async function testthatEntryPoint(
         test = test.parent;
         isDescribe = true;
     }
+    let config = vscode.workspace.getConfiguration("RTestAdapter");
+    let rRootPackage: string = config.get<string>("RPackageRoot")!;
+    if (rRootPackage == "") {
+        rRootPackage = vscode.workspace.getWorkspaceFolder(test.uri!)!.uri.fsPath.replace(/\\/g, "/");
+    }
     const testLabel = test?.label;
     const testPath = test?.uri!.fsPath.replace(/\\/g, "/");
-    let workspaceFolder = vscode.workspace.getWorkspaceFolder(test.uri!)!.uri.fsPath.replace(/\\/g, "/");
 
     return `
 # NOTE! This file has been generated automatically by the VSCode R Test Adapter. Modification has no effect.
@@ -93,12 +97,12 @@ if (!IS_WHOLE_FILE_TEST) {
 library(devtools)
 devtools::load_all('${testReporterPath}')
 if (IS_DEBUG) {
-    .vsc.load_all('${workspaceFolder}')
+    .vsc.load_all('${rRootPackage}')
     with_reporter(VSCodeReporter, {
         .vsc.debugSource('${testPath}')
     })
 } else {
-    devtools::load_all('${workspaceFolder}')
+    devtools::load_all('${rRootPackage}')
     devtools::${devtoolsMethod}('${testPath}', reporter=VSCodeReporter)
 }
 `;

--- a/src/testthat/watcher.ts
+++ b/src/testthat/watcher.ts
@@ -8,7 +8,9 @@ export async function testthatWatcherFactory(
     workspaceFolder: vscode.WorkspaceFolder
 ) {
     testingTools.log.info("Registering testthat watchers");
-    const pattern = new vscode.RelativePattern(workspaceFolder, "**/tests/testthat/**/test*.R");
+    let config = vscode.workspace.getConfiguration("RTestAdapter");
+    let testthatSearchPath: string | undefined = config.get("testthatSearchPath");
+    const pattern = new vscode.RelativePattern(workspaceFolder, testthatSearchPath!);
     const watcher = vscode.workspace.createFileSystemWatcher(pattern);
 
     // Check that tests are not from RCMD and are not temp files

--- a/src/tinytest/watcher.ts
+++ b/src/tinytest/watcher.ts
@@ -7,7 +7,9 @@ export async function tinytestWatcherFactory(
     workspaceFolder: vscode.WorkspaceFolder
 ) {
     testingTools.log.info("Registering testthat watchers");
-    const pattern = new vscode.RelativePattern(workspaceFolder, "**/inst/tinytest/**/test*.R");
+    let config = vscode.workspace.getConfiguration("RTestAdapter");
+    let tinytestSearchPath: string | undefined = config.get("tinytestSearchPath");
+    const pattern = new vscode.RelativePattern(workspaceFolder, tinytestSearchPath!);
     const watcher = vscode.workspace.createFileSystemWatcher(pattern);
 
     // Check that tests are not from RCMD and are not temp files

--- a/test/suite/e2e.test.ts
+++ b/test/suite/e2e.test.ts
@@ -1,0 +1,73 @@
+import * as vscode from "vscode";
+import { expect } from "chai";
+import { getTestingTools } from "../../src/main";
+import { rediscover } from "../../src/util";
+
+const ext = vscode.extensions.getExtension('meakbiyik.vscode-r-test-adapter');
+let config = vscode.workspace.getConfiguration("RTestAdapter");
+
+suite("end to end testing", () => {
+
+    test("Can rediscover tests after search path has been modified", async () => {
+        await ext!.activate();
+        let testingTools = getTestingTools();
+
+        await rediscover(testingTools);
+        expect(testingTools.controller.items.size).to.be.equal(11);
+
+        await config.update(
+            'testthatSearchPath',
+            'dummy_empty_path',
+            vscode.ConfigurationTarget.Workspace
+        );
+
+        await rediscover(testingTools);
+        expect(testingTools.controller.items.size).to.be.equal(6);
+
+        await config.update(
+            'tinytestSearchPath',
+            'dummy_empty_path',
+            vscode.ConfigurationTarget.Workspace
+        );
+
+        await rediscover(testingTools);
+        expect(testingTools.controller.items.size).to.be.equal(0);
+
+        // clean up of options
+        await config.update(
+            'testthatSearchPath',
+            undefined,
+            vscode.ConfigurationTarget.Workspace
+        );
+        await config.update(
+            'tinytestSearchPath',
+            undefined,
+            vscode.ConfigurationTarget.Workspace
+        );
+
+        await rediscover(testingTools);
+        expect(testingTools.controller.items.size).to.be.equal(11);
+
+    });
+
+    test("Can load packages in entry point", async () => {
+        await ext!.activate();
+        let testingTools = getTestingTools();
+
+        await config.update(
+            "RPackageRoot",
+            "../testRepo",  // faking some path but effectively pointing to the original R package
+            vscode.ConfigurationTarget.Workspace
+        );
+        await rediscover(testingTools);
+        expect(testingTools.controller.items.size).to.be.equal(11);
+
+        // clean up of options
+        await config.update(
+            "RPackageRoot",
+            undefined,
+            vscode.ConfigurationTarget.Workspace
+        );
+        expect(testingTools.controller.items.size).to.be.equal(11);
+    });
+});


### PR DESCRIPTION
_Note: this PR depends on:
 - https://github.com/meakbiyik/vscode-r-test-adapter/pull/45 which fixes a non-critical issue but with a rather higher priority preventing the tests from being green
 - https://github.com/meakbiyik/vscode-r-test-adapter/pull/43 which fixes the "refresh tests" button in a weird case; that PR is ready for merge and we need to align this PR with it because there are merge conflicts_

This PR adds 2 things in .vscode/settings.json:

 1. test search paths: it enables setting search paths for `testthat` and `tinytest` relative to current workspace folder
 2. let's the user specify the R root package path (resolves https://github.com/meakbiyik/vscode-r-test-adapter/issues/37)

### Test search paths

There are 2 new options: `RTestAdapter.testthatSearchPath` and `RTestAdapter.tinytestSearchPath` for specifying test search paths relative to the current workspace folder. The user can modify settings.json and then hit the 'rediscover tests' button in the Testing Tab. The discovered tests in the Testing Tab will be updated accordingly.

<img width="766" height="391" alt="image" src="https://github.com/user-attachments/assets/aeedd1bb-ea57-4ed9-b7eb-846a67536531" />

Sample usage:

```json
// .vscode/settings.json
{
    "RTestAdapter.testthatSearchPath": "**/tests/testthat/**/test*.R",  // default
    "RTestAdapter.tinytestSearchPath": "**/inst/tinytest/**/test*.R"    // default
}
```

### R root package

The new `RTestAdapter.RPackageRoot` lets the user specify the root path of the R package we are testing. Empty value means workspace root folder.

```json
// .vscode/settings.json
{
    "RTestAdapter.RPackageRoot": "/path/to/the/R/package"    // example
}
```
