### PR TITLE
Fixed handling of multiple workspace folders

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -148,7 +148,7 @@ async function runTest(
     let cleanFilePath = tmpFilePath.replace(/\\/g, "/");
     let RscriptCommand = await getRscriptCommand(testingTools);
     let command = `${RscriptCommand} ${tmpFilePath}`;
-    let cwd = vscode.workspace.workspaceFolders![0];
+    let cwd = vscode.workspace.getWorkspaceFolder(test.uri!)!;
 
     // Use DebugChannel for debug mode to capture detailed debugging information,
     // and ProcessChannel for normal mode to execute the test script as a subprocess.

--- a/src/testthat/runner.ts
+++ b/src/testthat/runner.ts
@@ -6,8 +6,6 @@ import { appendFile as _appendFile } from "fs";
 const testReporterPath = path
     .join(__dirname, "..", "..", "..", "src", "testthat", "reporter")
     .replace(/\\/g, "/");
-const workspaceFolder = vscode.workspace.workspaceFolders![0].uri.fsPath
-    .replace(/\\/g, "/");
 
 // This function returns the 'entry point' for the R test.
 // The entry point hacks the testthat package to disable any other test.
@@ -40,8 +38,8 @@ export async function testthatEntryPoint(
         isDescribe = true;
     }
     const testLabel = test?.label;
-    const testPath = test?.uri!.fsPath
-        .replace(/\\/g, "/");
+    const testPath = test?.uri!.fsPath.replace(/\\/g, "/");
+    let workspaceFolder = vscode.workspace.getWorkspaceFolder(test.uri!)!.uri.fsPath.replace(/\\/g, "/");
 
     return `
 # NOTE! This file has been generated automatically by the VSCode R Test Adapter. Modification has no effect.

--- a/src/tinytest/runner.ts
+++ b/src/tinytest/runner.ts
@@ -14,8 +14,7 @@ export async function tinytestEntryPoint(
 ) {
   const file = test?.uri!.fsPath
     .replace(/\\/g, "/");
-  const workspaceFolder = vscode.workspace.workspaceFolders![0].uri.fsPath
-    .replace(/\\/g, "/");
+  let workspaceFolder = vscode.workspace.getWorkspaceFolder(test.uri!)!.uri.fsPath.replace(/\\/g, "/");
   return `
 
 # NOTE! This file has been generated automatically by the VSCode R Test Adapter. Modification has no effect.


### PR DESCRIPTION
Handling of workspace folders was broken in general case because the code was accessing only the first element of the array with workspace folders.